### PR TITLE
Handle panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,6 @@ singlefleet's execution batching takes two params:
 whichever comes first. If a given call (identified by their respective `id` argument) is currently in-flight (called and not yet returned), another incoming identical call will not initiate a new batch or be added to a newer pending batch; it will just wait for the result of the previous call (think singleflight).
 
 ## Future plans
-- Panic handling
+- ~~Panic handling~~
 - Make use of generics to enable custom types for `id` and return value
+- Handle runtime.Goexit

--- a/singlefleet_test.go
+++ b/singlefleet_test.go
@@ -47,6 +47,23 @@ func TestFetchErr(t *testing.T) {
 	}
 }
 
+func TestFetchPanic(t *testing.T) {
+	panicMsg := "panic"
+	f := NewFetcher(func(ids []string) (map[string]interface{}, error) {
+		panic(panicMsg)
+	}, 100*time.Millisecond, 1)
+	v, ok, err := f.Fetch("a")
+	if err == nil {
+		t.Errorf("Fetch error = nil; want error = %s", panicMsg)
+	}
+	if ok != false {
+		t.Errorf("Fetch ok = %v, want false", ok)
+	}
+	if v != nil {
+		t.Errorf("unexpected non-nil value %#v", v)
+	}
+}
+
 func TestFetchSingleBatchByMaxBatch(t *testing.T) {
 	var wg sync.WaitGroup
 	var ncall = 0


### PR DESCRIPTION
Recover panic caused by the defined job

Note:
- `errPanic` implementation copied from golang.org/x/sync/singleflight